### PR TITLE
do not rename references by default

### DIFF
--- a/.github/scripts/run-scoper.sh
+++ b/.github/scripts/run-scoper.sh
@@ -25,4 +25,4 @@ else
   cd matomo
 fi
 
-php8.2 "$MATOMO_SCOPER_PATH" scope -y .
+php8.2 "$MATOMO_SCOPER_PATH" scope -y --rename-references .

--- a/src/Prefixer.php
+++ b/src/Prefixer.php
@@ -33,7 +33,7 @@ abstract class Prefixer
         $this->composerProject = new ComposerProject($this->paths->getRepoPath(), $this->filesystem);
     }
 
-    public function run(): array
+    public function run(bool $renameReferences): array
     {
         if (empty($this->dependenciesToPrefix)) {
             return [];
@@ -42,7 +42,9 @@ abstract class Prefixer
         list($dependenciesToPrefix, $namespacesToInclude) = $this->collectChildDependencies();
 
         $this->scopeDependencies($dependenciesToPrefix, $namespacesToInclude);
-        $this->renameReferencesToScopedDependencies($dependenciesToPrefix, $namespacesToInclude);
+        if ($renameReferences) {
+            $this->renameReferencesToScopedDependencies($dependenciesToPrefix, $namespacesToInclude);
+        }
 
         return $dependenciesToPrefix;
     }

--- a/src/Prefixers/CorePrefixer.php
+++ b/src/Prefixers/CorePrefixer.php
@@ -39,11 +39,11 @@ class CorePrefixer extends Prefixer
         $this->dependenciesToIgnore = self::DEPENDENCIES_TO_IGNORE;
     }
 
-    public function run(): array
+    public function run(bool $renameReferences): array
     {
         $scoperIncFile = new CoreScoperInc($this->paths->getRepoPath());
         $scoperIncFile->writeIfNotExists();
 
-        return parent::run();
+        return parent::run($renameReferences);
     }
 }

--- a/src/Prefixers/PluginPrefixer.php
+++ b/src/Prefixers/PluginPrefixer.php
@@ -36,11 +36,11 @@ class PluginPrefixer extends Prefixer
         }
     }
 
-    public function run(): array
+    public function run(bool $renameReferences): array
     {
         $scoperIncFile = new PluginScoperInc($this->paths->getRepoPath(), $this->pluginDetails->getPluginName());
         $scoperIncFile->writeIfNotExists();
 
-        return parent::run();
+        return parent::run($renameReferences);
     }
 }

--- a/src/ScopeCommand.php
+++ b/src/ScopeCommand.php
@@ -38,6 +38,8 @@ class ScopeCommand extends Command
         $this->addOption('composer-path', null, InputOption::VALUE_REQUIRED,
             'Path to composer. Required to generate a new autoloader.', getenv('COMPOSER_BINARY') ?: 'composer');
         $this->addOption('yes', 'y', InputOption::VALUE_NONE, 'Bypass confirmation.');
+        $this->addOption('rename-references', null, InputOption::VALUE_NONE,
+            'Rename references in the main repo after prefixing dependencies. (Note: this will destroy formatting of PHP code so is not enabled by default.)');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -45,6 +47,7 @@ class ScopeCommand extends Command
         $repoPath = $input->getArgument('repo_path');
         $composerPath = $this->getComposerPath($input);
         $bypassConfirmation = $input->getOption('yes');
+        $renameReferences = $input->getOption('rename-references');
 
         $paths = new Paths($repoPath, $composerPath);
         $filesystem = new Filesystem();
@@ -74,7 +77,7 @@ class ScopeCommand extends Command
         }
 
         $output->writeln("<info>Prefixing dependencies...</info>");
-        $prefixedDependencies = $prefixer->run();
+        $prefixedDependencies = $prefixer->run($renameReferences);
         if (empty($prefixedDependencies)) {
             $output->writeln("<info>Nothing prefixed.</info>");
             return Command::SUCCESS;


### PR DESCRIPTION
### Description:

This feature is only needed for scoping core as part of an automated process. Developers running the tool manually probably wouldn't want to use it, since it destroys formatting of PHP code.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
