### PR TITLE
Add option to ignore platform check

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -11,7 +11,7 @@ namespace Matomo\Scoper;
 class Application extends \Symfony\Component\Console\Application
 {
     const APP_NAME = 'matomo-scoper';
-    const VERSION = '0.1.0';
+    const VERSION = '0.1.1';
 
     public function __construct()
     {

--- a/src/AutoloaderGenerator.php
+++ b/src/AutoloaderGenerator.php
@@ -25,6 +25,7 @@ class AutoloaderGenerator
         private readonly Filesystem $filesystem,
         private readonly OutputInterface $output,
         private readonly array $prefixedDependencies,
+        private readonly bool $ignorePlatformCheck,
     )
     {
         $this->composerProject = new ComposerProject($paths->getRepoPath(), $this->filesystem);
@@ -46,7 +47,7 @@ class AutoloaderGenerator
         $tempComposerJson = new TemporaryComposerJson($this->prefixedDependencies, $this->composerProject);
         $tempComposerJson->write();
 
-        $dumpAutoload = new DumpAutoload($this->paths, $this->output, $repoPath . '/vendor/prefixed');
+        $dumpAutoload = new DumpAutoload($this->paths, $this->output, $repoPath . '/vendor/prefixed', $this->ignorePlatformCheck);
         $dumpAutoload->passthru();;
 
         // TODO: why do we do this again?
@@ -70,8 +71,8 @@ class AutoloaderGenerator
         $this->composerProject->createDummyComposerJsonFilesForPrefixedDeps();
 
         try {
-            $regenerateUnprefixedAutload = new DumpAutoload($this->paths, $this->output, $repoPath);
-            $regenerateUnprefixedAutload->passthru();;
+            $regenerateUnprefixedAutload = new DumpAutoload($this->paths, $this->output, $repoPath, $this->ignorePlatformCheck);
+            $regenerateUnprefixedAutload->passthru();
         } finally {
             $this->composerProject->removeDummyComposerJsonFilesForPrefixedDeps();
         }

--- a/src/ScopeCommand.php
+++ b/src/ScopeCommand.php
@@ -41,7 +41,7 @@ class ScopeCommand extends Command
         $this->addOption('rename-references', null, InputOption::VALUE_NONE,
             'Rename references in the main repo after prefixing dependencies. (Note: this will destroy formatting of PHP code so is not enabled by default.)');
         $this->addOption('ignore-platform-check', null, InputOption::VALUE_NONE,
-            'Remove the platform check when the new autoloader is generated.)');
+            'Remove the platform check when the new autoloader is generated.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/ScopeCommand.php
+++ b/src/ScopeCommand.php
@@ -40,6 +40,8 @@ class ScopeCommand extends Command
         $this->addOption('yes', 'y', InputOption::VALUE_NONE, 'Bypass confirmation.');
         $this->addOption('rename-references', null, InputOption::VALUE_NONE,
             'Rename references in the main repo after prefixing dependencies. (Note: this will destroy formatting of PHP code so is not enabled by default.)');
+        $this->addOption('ignore-platform-check', null, InputOption::VALUE_NONE,
+            'Remove the platform check when the new autoloader is generated.)');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -48,6 +50,7 @@ class ScopeCommand extends Command
         $composerPath = $this->getComposerPath($input);
         $bypassConfirmation = $input->getOption('yes');
         $renameReferences = $input->getOption('rename-references');
+        $ignorePlatformCheck = $input->getOption('ignore-platform-check');
 
         $paths = new Paths($repoPath, $composerPath);
         $filesystem = new Filesystem();
@@ -86,7 +89,7 @@ class ScopeCommand extends Command
         $output->writeln("");
         $output->writeln("<info>Regenerating autoloader...</info>");
 
-        $autoloaderGenerator = new AutoloaderGenerator($paths, $filesystem, $output, $prefixedDependencies);
+        $autoloaderGenerator = new AutoloaderGenerator($paths, $filesystem, $output, $prefixedDependencies, $ignorePlatformCheck);
         $autoloaderGenerator->generate();
 
         $output->writeln("<info>Done.</info>");

--- a/src/ShellCommands/DumpAutoload.php
+++ b/src/ShellCommands/DumpAutoload.php
@@ -18,11 +18,14 @@ class DumpAutoload extends ShellCommand
 
     private string $workingDirectory;
 
-    public function __construct(Paths $paths, OutputInterface $output, string $workingDirectory)
+    private bool $ignorePlatformCheck;
+
+    public function __construct(Paths $paths, OutputInterface $output, string $workingDirectory, bool $ignorePlatformCheck)
     {
         parent::__construct($output);
         $this->paths = $paths;
         $this->workingDirectory = $workingDirectory;
+        $this->ignorePlatformCheck = $ignorePlatformCheck;
     }
 
     public function getCommand(): string
@@ -30,6 +33,11 @@ class DumpAutoload extends ShellCommand
         $composerPath = $this->paths->getComposerPath();
         $composerCommand = escapeshellarg($composerPath) . " --working-dir=" . escapeshellarg($this->workingDirectory)
             . " dump-autoload -o --no-interaction";
+
+        if ($this->ignorePlatformCheck) {
+            $composerCommand .= ' --ignore-platform-reqs';
+        }
+
         return $composerCommand;
     }
 }

--- a/tests/ShellCommands/DumpAutoloadTest.php
+++ b/tests/ShellCommands/DumpAutoloadTest.php
@@ -18,10 +18,21 @@ class DumpAutoloadTest extends TestCase
     public function test_getCommand_constructsCorrectCommand()
     {
         $paths = new Paths('/path/to/matomo', '/path/to/composer');
-        $command = new DumpAutoload($paths, new NullOutput(), '/path/to/matomo/plugins/plugin');
+        $command = new DumpAutoload($paths, new NullOutput(), '/path/to/matomo/plugins/plugin', false);
 
         $actualCommand = $command->getCommand();
         $expectedCommand = "'/path/to/composer' --working-dir='/path/to/matomo/plugins/plugin' dump-autoload -o --no-interaction";
+
+        $this->assertEquals($expectedCommand, $actualCommand);
+    }
+
+    public function test_getCommand_constructsCorrectCommandWithIgnorePlatformCheck()
+    {
+        $paths = new Paths('/path/to/matomo', '/path/to/composer');
+        $command = new DumpAutoload($paths, new NullOutput(), '/path/to/matomo/plugins/plugin', true);
+
+        $actualCommand = $command->getCommand();
+        $expectedCommand = "'/path/to/composer' --working-dir='/path/to/matomo/plugins/plugin' dump-autoload -o --no-interaction --ignore-platform-reqs";
 
         $this->assertEquals($expectedCommand, $actualCommand);
     }

--- a/tests/ShellCommands/DumpAutoloadTest.php
+++ b/tests/ShellCommands/DumpAutoloadTest.php
@@ -15,25 +15,34 @@ use Symfony\Component\Console\Output\NullOutput;
 
 class DumpAutoloadTest extends TestCase
 {
-    public function test_getCommand_constructsCorrectCommand()
+    /**
+     * @dataProvider get_getCommand_testValues
+     *
+     * @param bool $ignorePlatformCheck
+     * @param string $expectedCommand
+     * @return void
+     */
+    public function test_getCommand_constructsCorrectCommand(bool $ignorePlatformCheck, string $expectedCommand)
     {
         $paths = new Paths('/path/to/matomo', '/path/to/composer');
-        $command = new DumpAutoload($paths, new NullOutput(), '/path/to/matomo/plugins/plugin', false);
+        $command = new DumpAutoload($paths, new NullOutput(), '/path/to/matomo/plugins/plugin', $ignorePlatformCheck);
 
         $actualCommand = $command->getCommand();
-        $expectedCommand = "'/path/to/composer' --working-dir='/path/to/matomo/plugins/plugin' dump-autoload -o --no-interaction";
 
-        $this->assertEquals($expectedCommand, $actualCommand);
+        $this->assertEquals($expectedCommand, $actualCommand, "When ignorePlatform is {$ignorePlatformCheck}, the expected command is: {$expectedCommand}");
     }
 
-    public function test_getCommand_constructsCorrectCommandWithIgnorePlatformCheck()
+    public static function get_getCommand_testValues()
     {
-        $paths = new Paths('/path/to/matomo', '/path/to/composer');
-        $command = new DumpAutoload($paths, new NullOutput(), '/path/to/matomo/plugins/plugin', true);
-
-        $actualCommand = $command->getCommand();
-        $expectedCommand = "'/path/to/composer' --working-dir='/path/to/matomo/plugins/plugin' dump-autoload -o --no-interaction --ignore-platform-reqs";
-
-        $this->assertEquals($expectedCommand, $actualCommand);
+        return [
+            [
+                false,
+                "'/path/to/composer' --working-dir='/path/to/matomo/plugins/plugin' dump-autoload -o --no-interaction",
+            ],
+            [
+                true,
+                "'/path/to/composer' --working-dir='/path/to/matomo/plugins/plugin' dump-autoload -o --no-interaction --ignore-platform-reqs",
+            ],
+        ];
     }
 }


### PR DESCRIPTION
### Description:

I was running into the issue that the platform check was still happening despite having it disabled in my composer.json file. I realised that it was getting added back into the autoloader during the scoping process. This adds the option to exclude the platform check from the autoload files.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
