### PR TITLE
make sure \Normalizer is not prefixed when used in defined() call

### DIFF
--- a/resources/core-scoper.inc.php
+++ b/resources/core-scoper.inc.php
@@ -163,5 +163,6 @@ return [
     'exclude-namespaces' => $namespacesToExclude,
     'exclude-constants' => [
         '/^self::/', // work around php-scoper bug
+        '/^Normalizer::/',
     ],
 ];


### PR DESCRIPTION
### Description:

`symfony/string` has a check for `defined(Normalizer::NFKC_CF)`, which gets prefixed due to a bug in php-scoper. Excluding it in scoper.inc.php file for core works around the issue.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
