### PR TITLE
ignore more symfony polyfills

### DIFF
--- a/src/Prefixers/CorePrefixer.php
+++ b/src/Prefixers/CorePrefixer.php
@@ -29,6 +29,10 @@ class CorePrefixer extends Prefixer
     const DEPENDENCIES_TO_IGNORE = [
         'symfony/polyfill-php80',
         'symfony/polyfill-php73',
+        'symfony/polyfill-ctype',
+        'symfony/polyfill-intl-grapheme',
+        'symfony/polyfill-intl-normalizer',
+        'symfony/polyfill-mbstring',
     ];
 
     public function __construct(Paths $paths, Filesystem $filesystem, OutputInterface $output)


### PR DESCRIPTION
### Description:

They should not be prefixed since they check for and set global functions/classes.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
