### PR TITLE
do not prefix PHP templates

### DIFF
--- a/resources/core-scoper.inc.php
+++ b/resources/core-scoper.inc.php
@@ -148,6 +148,8 @@ return [
 
             if (preg_match('%php-di/php-di/src/Compiler/Template\\.php$%', $filePath)
                 || preg_match('%symfony/error-handler/Resources/.*\\.php$%', $filePath)
+                || preg_match('%symfony/http-kernel/Resources/.*\\.php$%', $filePath)
+                || preg_match('%symfony/var-dumper/Resources/bin/var-dump-server$%', $filePath)
             ) {
                 $content = preg_replace('%namespace Matomo\\\\Dependencies;\s+%', '', $content);
             }

--- a/resources/core-scoper.inc.php
+++ b/resources/core-scoper.inc.php
@@ -140,13 +140,15 @@ return [
             return $content;
         },
 
-        // patchers for php-di
+        // patcher to remove prefixing from template files
         static function (string $filePath, string $prefix, string $content) use ($isRenamingReferences): string {
             if ($isRenamingReferences) {
                 return $content;
             }
 
-            if (preg_match('%src/Compiler/Template\\.php$%', $filePath)) {
+            if (preg_match('%php-di/php-di/src/Compiler/Template\\.php$%', $filePath)
+                || preg_match('%symfony/error-handler/Resources/.*\\.php$%', $filePath)
+            ) {
                 $content = preg_replace('%namespace Matomo\\\\Dependencies;\s+%', '', $content);
             }
 

--- a/resources/core-scoper.inc.php
+++ b/resources/core-scoper.inc.php
@@ -57,9 +57,10 @@ if ($isRenamingReferences) {
     $forceNoGlobalAlias = true;
 } else {
     $finders = array_map(function ($dependency) {
-        return Finder::create()
+        $finder = Finder::create()
             ->files()
             ->in($dependency);
+        return $finder;
     }, $dependenciesToPrefix);
 }
 
@@ -134,6 +135,19 @@ return [
                 || preg_match('%symfony/polyfill-intl-normalizer/Resources/unidata/compatibilityDecomposition\\.php$%', $filePath)
             ) {
                 $content = str_replace(html_entity_decode('&nbsp;'), "\\xC2\\xA0", $content);
+            }
+
+            return $content;
+        },
+
+        // patchers for php-di
+        static function (string $filePath, string $prefix, string $content) use ($isRenamingReferences): string {
+            if ($isRenamingReferences) {
+                return $content;
+            }
+
+            if (preg_match('%src/Compiler/Template\\.php$%', $filePath)) {
+                $content = preg_replace('%namespace Matomo\\\\Dependencies;\s+%', '', $content);
             }
 
             return $content;


### PR DESCRIPTION
### Description:

PHP files in several dependencies are used as templates instead of just defining PHP code. These should not be prefixed, but should still be copied over.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
