### PR TITLE
prefix pear/pear_exception

### DIFF
--- a/resources/core-scoper.inc.php
+++ b/resources/core-scoper.inc.php
@@ -77,6 +77,17 @@ return [
     'prefix' => 'Matomo\\Dependencies',
     'finders' => $finders,
     'patchers' => [
+        // patchers for PEAR (pear libraries do not use psr autoloading and put everything in a global namespace,
+        // so we can't automatically rename references to PEAR libraries)
+        static function (string $filePath, string $prefix, string $content) use ($isRenamingReferences): string {
+            if (!$isRenamingReferences) {
+                return $content;
+            }
+
+            $content = preg_replace('/([^\\\\A-Za-z0-9_])\\\\PEAR_/', '$1\\Matomo\\Dependencies\\PEAR_', $content);
+            return $content;
+        },
+
         // patchers for twig
         static function (string $filePath, string $prefix, string $content) use ($isRenamingReferences): string {
             // correct use statements in generated templates

--- a/src/Prefixers/CorePrefixer.php
+++ b/src/Prefixers/CorePrefixer.php
@@ -26,6 +26,10 @@ class CorePrefixer extends Prefixer
         'php-di/php-di',
         'geoip2/geoip2',
         'pear/pear_exception',
+        'pear/archive_tar',
+        'pear/console_getopt',
+        'pear/pear-core-minimal',
+        'pear/pear_exception',
     ];
 
     const DEPENDENCIES_TO_IGNORE = [

--- a/src/Prefixers/CorePrefixer.php
+++ b/src/Prefixers/CorePrefixer.php
@@ -25,6 +25,7 @@ class CorePrefixer extends Prefixer
         'symfony/console', // new version now depends on service-contracts which symfony/monolog-bridge also depends on
         'php-di/php-di',
         'geoip2/geoip2',
+        'pear/pear_exception',
     ];
 
     const DEPENDENCIES_TO_IGNORE = [


### PR DESCRIPTION
### Description:

As title. For WP compatibility with CiviCRM.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
