### PR TITLE
add patcher for core that puts SensitiveParameter attribute on its own line for PHP 7.2

### DIFF
--- a/resources/core-scoper.inc.php
+++ b/resources/core-scoper.inc.php
@@ -202,7 +202,7 @@ return [
 
         // patcher to make sure #[\SensitiveParameter] is on a newline by itself
         static function (string $filePath, string $prefix, string $content): string {
-            $content = preg_replace('/(\S) #\\[\\\\SensitiveParameter] (\S)/', "\\1\n#[\\SensitiveParameter]\n\\2", $content);
+            $content = preg_replace('/(\S)\s*#\\[\\\\SensitiveParameter]\s*(\S)/', "\\1\n#[\\SensitiveParameter]\n\\2", $content);
             return $content;
         },
 

--- a/resources/core-scoper.inc.php
+++ b/resources/core-scoper.inc.php
@@ -200,6 +200,12 @@ return [
             return $content;
         },
 
+        // patcher to make sure #[\SensitiveParameter] is on a newline by itself
+        static function (string $filePath, string $prefix, string $content): string {
+            $content = preg_replace('/(\S) #\\[\\\\SensitiveParameter] (\S)/', "\\1\n#[\\SensitiveParameter]\n\\2", $content);
+            return $content;
+        },
+
         // test related patchers
         static function (string $filePath, string $prefix, string $content) use ($isRenamingReferences): string {
             if (!$isRenamingReferences) {


### PR DESCRIPTION
### Description:

As title. Without this change, the use of `#[\SensitiveParameter]` will be on a single line, causing problems for PHP 7.2.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
