### PR TITLE
Prefix wikimedia/less.php in core

### DIFF
--- a/resources/core-scoper.inc.php
+++ b/resources/core-scoper.inc.php
@@ -115,6 +115,18 @@ return [
 
         // patchers for less.php
         static function (string $filePath, string $prefix, string $content) use ($isRenamingReferences): string {
+            if ($isRenamingReferences) {
+                return $content;
+            }
+
+            if (str_ends_with($filePath, 'wikimedia/less.php/lib/Less/Parser.php')) {
+                $content = str_replace('$obj = new $class(...$args);', "\$class = 'Matomo\\\\Dependencies\\\\' . \$class;\n        \$obj = new \$class(...\$args);", $content);
+            }
+
+            return $content;
+        },
+
+        static function (string $filePath, string $prefix, string $content) use ($isRenamingReferences): string {
             if (!$isRenamingReferences) {
                 return $content;
             }

--- a/resources/core-scoper.inc.php
+++ b/resources/core-scoper.inc.php
@@ -123,6 +123,10 @@ return [
                 $content = str_replace('$obj = new $class(...$args);', "\$class = 'Matomo\\\\Dependencies\\\\' . \$class;\n        \$obj = new \$class(...\$args);", $content);
             }
 
+            if (strpos($filePath, 'wikimedia/less.php') !== false) {
+                $content = str_replace("'Less_Functions'", "'Matomo\\\\Dependencies\\\\Less_Functions'", $content);
+            }
+
             return $content;
         },
 
@@ -135,6 +139,7 @@ return [
                 $content = str_replace('"lessc"', '"\\\\Matomo\\\\Dependencies\\\\lessc"', $content);
                 $content = str_replace('use lessc;', 'use Matomo\\Dependencies\\lessc;', $content);
             }
+
             return $content;
         },
 

--- a/resources/core-scoper.inc.php
+++ b/resources/core-scoper.inc.php
@@ -113,6 +113,19 @@ return [
             return $content;
         },
 
+        // patchers for less.php
+        static function (string $filePath, string $prefix, string $content) use ($isRenamingReferences): string {
+            if (!$isRenamingReferences) {
+                return $content;
+            }
+
+            if (str_ends_with($filePath, '.php')) {
+                $content = str_replace('"lessc"', '"\\\\Matomo\\\\Dependencies\\\\lessc"', $content);
+                $content = str_replace('use lessc;', 'use Matomo\\Dependencies\\lessc;', $content);
+            }
+            return $content;
+        },
+
         // patchers for twig
         static function (string $filePath, string $prefix, string $content) use ($isRenamingReferences): string {
             // correct use statements in generated templates

--- a/src/Prefixers/CorePrefixer.php
+++ b/src/Prefixers/CorePrefixer.php
@@ -29,6 +29,7 @@ class CorePrefixer extends Prefixer
         'pear/archive_tar',
         'pear/console_getopt',
         'pear/pear-core-minimal',
+        'wikimedia/less.php',
     ];
 
     const DEPENDENCIES_TO_IGNORE = [


### PR DESCRIPTION
### Description

Different version used by wordpress.com and other WordPress plugins, so this is necessary to avoid autoload conflicts.

Related PR: https://github.com/matomo-org/matomo-for-wordpress/pull/1345

### Checklist

- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
